### PR TITLE
Allow issues to be pulled xx seconds after the commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ These can be specified using environment variables
 * TARGET_TAG_REGEX:  Regular expression of the release tags to search (ie: ^release-.*$)
 * TZ: The timezone for your release notes 
   * Default "Australia/Melbourne"
-* CLOSED_ISSUE_SECONDS: The amount of seconds to search after the last commit,  useful for Merge Requests that close their tickets a secon after the commit.
+* CLOSED_ISSUE_SECONDS: The amount of seconds to search after the last commit,  useful for Merge Requests that close their tickets a second after the commit.
   * Default 0
 
 ## TODO:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ docker container run -e GITLAB_PERSONAL_TOKEN=gitlabSampleToken -e GITLAB_PROJEC
 Reference gitlab repo: [generator test](https://gitlab.com/jackzhang/generator-test)
 
 
+## Options
+
+These can be specified using environment variables
+
+* GITLAB_API_ENDPOINT: Your gitlab instaqnce's endpoint 
+  * Default https://gitlab.com/api/v4
+* GITLAB_PERSONAL_TOKEN: Grant api read/access permission
+* GITLAB_PROJECT_ID: Your project id that is located under settings > general
+* TARGET_BRANCH: The branch to look for release tags (ie master)
+* TARGET_TAG_REGEX:  Regular expression of the release tags to search (ie: ^release-.*$)
+* TZ: The timezone for your release notes 
+  * Default "Australia/Melbourne"
+* CLOSED_ISSUE_SECONDS: The amount of seconds to search after the last commit,  useful for Merge Requests that close their tickets a secon after the commit.
+  * Default 0
+
 ## TODO:
 ### Feature
 - Release notes generation on selected tag

--- a/README.md
+++ b/README.md
@@ -66,8 +66,30 @@ These can be specified using environment variables
 * TARGET_TAG_REGEX:  Regular expression of the release tags to search (ie: ^release-.*$)
 * TZ: The timezone for your release notes 
   * Default "Australia/Melbourne"
-* CLOSED_ISSUE_SECONDS: The amount of seconds to search after the last commit,  useful for Merge Requests that close their tickets a second after the commit.
+* ISSUE_CLOSED_SECONDS: The amount of seconds to search after the last commit,  useful for Merge Requests that close their tickets a second after the commit.
   * Default 0
+
+## Building and Running locally
+
+```bash
+export GITLAB_PERSONAL_TOKEN=MYGITLABACCESSTOKEN
+export GITLAB_PROJECT_ID=99
+export GITLAB_API_ENDPOINT=https://my.gitlab.com/api/v4
+
+// run docker to build my local version
+docker build -t local-gitlab-release-note-generator .
+
+// run my local version
+docker container run \
+  -e TZ=America/New_York \
+  -e GITLAB_API_ENDPOINT=$GITLAB_API_ENDPOINT \
+  -e GITLAB_PERSONAL_TOKEN=$GITLAB_PERSONAL_TOKEN \
+  -e GITLAB_PROJECT_ID=$GITLAB_PROJECT_ID \
+  -e TARGET_BRANCH=master \
+  -e TARGET_TAG_REGEX=^release-.*$ \
+  local-gitlab-release-note-generator
+
+```
 
 ## TODO:
 ### Feature

--- a/app/env.js
+++ b/app/env.js
@@ -5,3 +5,7 @@ exports.TARGET_BRANCH = process.env.TARGET_BRANCH;
 exports.TARGET_TAG_REGEX = process.env.TARGET_TAG_REGEX ? new RegExp(process.env.TARGET_TAG_REGEX): undefined;
 exports.TZ = process.env.TZ || "Australia/Melbourne"; // TZ variable is for better logging
 exports.NODE_ENV = process.env.NODE_ENV;
+
+// will looks for issues closed this many seconds after the tag,  this may happen if the issue is merged via a MR and automatially closed
+// example -e GITLAB_ISSUE_SECOND_DELAY=60 will catch issues closed up to 60 seconds after the tag is created.
+exports.ISSUE_CLOSED_SECONDS = process.env.ISSUE_CLOSED_SECONDS || "0" 

--- a/app/lib/generator.js
+++ b/app/lib/generator.js
@@ -18,10 +18,10 @@ exports.generate = async () => {
 
   // allow the end date to be adjusted by a few seconds to catch issues that are automatially closed by
   // a MR and are time stamped a few seconds later.
-  Logger.debug(`EndDate:      ${endDate}`);
-  const parsedDate = new Date(Date.parse(endDate))
-  const newEndDate = new Date(parsedDate.getTime() + (1000 * Env.ISSUE_CLOSED_SECONDS)).toISOString()
-  Logger.debug(`New End Date: ${newEndDate}`);
+  Logger.debug(`EndDate:        ${endDate}`);
+  Logger.debug(`Adding Seconds: ${Env.ISSUE_CLOSED_SECONDS}`);
+  const newEndDate = new Moment(endDate).add(Env.ISSUE_CLOSED_SECONDS, 'seconds').utc().format();
+  Logger.debug(`New End Date:   ${newEndDate}`);
 
   const changeLog = await ChangelogLib.getChangelogByStartAndEndDate(startDate, newEndDate);
   const changeLogContent = await ChangelogLib.generateChangeLogContent(changeLog, {useSlack: false});

--- a/app/lib/generator.js
+++ b/app/lib/generator.js
@@ -14,16 +14,18 @@ exports.generate = async () => {
 
   if (!_.get(latestTag, "commit.committed_date") || !_.get(secondLatestTag, "commit.committed_date")) throw new Error(`Cannot find latest and second latest tag. Abort the program!`);
   const startDate = _.get(secondLatestTag, "commit.committed_date");
-  const endDate = _.get(latestTag, "commit.committed_date");
+  let endDate = _.get(latestTag, "commit.committed_date");
 
   // allow the end date to be adjusted by a few seconds to catch issues that are automatially closed by
   // a MR and are time stamped a few seconds later.
-  Logger.debug(`EndDate:        ${endDate}`);
-  Logger.debug(`Adding Seconds: ${Env.ISSUE_CLOSED_SECONDS}`);
-  const newEndDate = new Moment(endDate).add(Env.ISSUE_CLOSED_SECONDS, 'seconds').utc().format();
-  Logger.debug(`New End Date:   ${newEndDate}`);
+  if (Env.ISSUE_CLOSED_SECONDS > 0) {
+    Logger.debug(`EndDate:        ${endDate}`);
+    Logger.debug(`Adding Seconds: ${Env.ISSUE_CLOSED_SECONDS}`);
+    endDate = Moment.tz(endDate, Env.TZ).add(Env.ISSUE_CLOSED_SECONDS, "seconds").utc().format();
+    Logger.debug(`New End Date:   ${endDate}`);
+  }
 
-  const changeLog = await ChangelogLib.getChangelogByStartAndEndDate(startDate, newEndDate);
+  const changeLog = await ChangelogLib.getChangelogByStartAndEndDate(startDate, endDate);
   const changeLogContent = await ChangelogLib.generateChangeLogContent(changeLog, {useSlack: false});
   Logger.debug(`Changelog: ${changeLogContent}`);
   return await TagLib.upsertTagDescriptionByProjectIdAndTag(Env.GITLAB_PROJECT_ID, latestTag, changeLogContent);


### PR DESCRIPTION
Related to issue #8, this gives a configurable amount of seconds to search after the commit.  In my case when I automatically close a ticket from a Merge Request the ticket's timestamp is 1 second after the commit.