### PR TITLE
Feature/add changelog link

### DIFF
--- a/app/lib/changelog.js
+++ b/app/lib/changelog.js
@@ -4,6 +4,7 @@ const MergeRequestLib = require("./mergeRequest");
 const Moment = require("moment-timezone");
 const Env = require("../env");
 const Logger = require("../logger");
+const Gitlab = require("../adapters/gitlab");
 
 // Changelog available format
 exports.CHANGELOG_FORMAT_SLACK = "slack-format";
@@ -33,8 +34,11 @@ exports.generateChangeLogContent = async ({ releaseDate, issues, mergeRequests }
     { name: "issues", title: "Closed issues", default: true },
     { name: "mergeRequests", title: "Merged merge requests", default: true }
   ];
+  const project = await Gitlab.getRepoByProjectId(Env.GITLAB_PROJECT_ID);
+  const changelogUrl = `${project.web_url}/compare/${options.tags[1].name}...${options.tags[0].name}`;
   if (options.useSlack) {
     let changelogContent = `*Release note (${Moment.tz(releaseDate, Env.TZ).format("YYYY-MM-DD")})*\n`;
+    changelogContent += `<${changelogUrl}|Full Changelog>\n`;
     for (const labelConfig of labelConfigs) {
       if (changelogBucket[labelConfig.name]) {
         changelogContent += `*${labelConfig.title}*\n`;
@@ -44,6 +48,7 @@ exports.generateChangeLogContent = async ({ releaseDate, issues, mergeRequests }
     return changelogContent;
   } else {
     let changelogContent = `### Release note (${Moment.tz(releaseDate, Env.TZ).format("YYYY-MM-DD")})\n`;
+    changelogContent += `[Full Changelog](${changelogUrl})\n`;
     for (const labelConfig of labelConfigs) {
       if (changelogBucket[labelConfig.name]) {
           if (!_.isEmpty(changelogBucket[labelConfig.name]) || labelConfig.default) {

--- a/app/lib/changelog.js
+++ b/app/lib/changelog.js
@@ -38,7 +38,9 @@ exports.generateChangeLogContent = async ({ releaseDate, issues, mergeRequests }
   const changelogUrl = `${project.web_url}/compare/${options.tags[1].name}...${options.tags[0].name}`;
   if (options.useSlack) {
     let changelogContent = `*Release note (${Moment.tz(releaseDate, Env.TZ).format("YYYY-MM-DD")})*\n`;
-    changelogContent += `<${changelogUrl}|Full Changelog>\n`;
+    if(options.fullChangelogLink) {
+      changelogContent += `<${changelogUrl}|Full Changelog>\n`;
+    }
     for (const labelConfig of labelConfigs) {
       if (changelogBucket[labelConfig.name]) {
         changelogContent += `*${labelConfig.title}*\n`;
@@ -48,7 +50,9 @@ exports.generateChangeLogContent = async ({ releaseDate, issues, mergeRequests }
     return changelogContent;
   } else {
     let changelogContent = `### Release note (${Moment.tz(releaseDate, Env.TZ).format("YYYY-MM-DD")})\n`;
-    changelogContent += `[Full Changelog](${changelogUrl})\n`;
+    if (options.fullChangelogLink) {
+      changelogContent += `[Full Changelog](${changelogUrl})\n`;
+    }
     for (const labelConfig of labelConfigs) {
       if (changelogBucket[labelConfig.name]) {
           if (!_.isEmpty(changelogBucket[labelConfig.name]) || labelConfig.default) {

--- a/app/lib/generator.js
+++ b/app/lib/generator.js
@@ -26,7 +26,7 @@ exports.generate = async () => {
   }
 
   const changeLog = await ChangelogLib.getChangelogByStartAndEndDate(startDate, endDate);
-  const changeLogContent = await ChangelogLib.generateChangeLogContent(changeLog, {useSlack: false});
+  const changeLogContent = await ChangelogLib.generateChangeLogContent(changeLog, {tags, useSlack: false});
   Logger.debug(`Changelog: ${changeLogContent}`);
   return await TagLib.upsertTagDescriptionByProjectIdAndTag(Env.GITLAB_PROJECT_ID, latestTag, changeLogContent);
 };

--- a/app/lib/generator.js
+++ b/app/lib/generator.js
@@ -26,7 +26,7 @@ exports.generate = async () => {
   }
 
   const changeLog = await ChangelogLib.getChangelogByStartAndEndDate(startDate, endDate);
-  const changeLogContent = await ChangelogLib.generateChangeLogContent(changeLog, {tags, useSlack: false});
+  const changeLogContent = await ChangelogLib.generateChangeLogContent(changeLog, {tags, fullChangelogLink: true, useSlack: false});
   Logger.debug(`Changelog: ${changeLogContent}`);
   return await TagLib.upsertTagDescriptionByProjectIdAndTag(Env.GITLAB_PROJECT_ID, latestTag, changeLogContent);
 };


### PR DESCRIPTION
The documentation of the [original repo](https://github.com/github-changelog-generator/github-changelog-generator) links to this output example
https://github.com/github-changelog-generator/Github-Changelog-Generator/blob/master/CHANGELOG.md

That example includes a "Full Changelog" link, which basically uses the GitHub compare functionality.

This PR adds the ability to include a Full Changelog for GitLab as well.