### PR TITLE
Fix gitlab api

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A Gitlab release note generator that generates release note on latest tag
 5. Generate a release note/changelog based on the findings above.
 
 ## Software requirement
-- NodeJS ^10.x.x OR docker
+- NodeJS ^16.x.x OR docker
 - A gitlab personal access token with `api` permission. [How to Tutorial](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 
 ## How to run this app

--- a/app/adapters/gitlab.js
+++ b/app/adapters/gitlab.js
@@ -94,7 +94,7 @@ module.exports = class GitlabAdapter {
     async createTagReleaseByProjectIdTagNameAndTagId(projectId, tagName, body) {
         const response = await Got.post(`${this.GITLAB_API_ENDPOINT}/projects/${projectId}/releases`, {
             ...this.gotDefaultOptions,
-            json: { ...body, tagName }
+            json: { ...body, tag_name: tagName }
         });
         return response.body;
     }

--- a/app/index.js
+++ b/app/index.js
@@ -10,7 +10,7 @@ const container = ConfigureContainer();
 (async () => {
     try {
         let env = null;
-        if (process.env.GITLAB_API_ENDPOINT && process.env.GITLAB_PROJECT_ID) {
+        if (process.env.GITLAB_PERSONAL_TOKEN && process.env.GITLAB_PROJECT_ID) {
             // eslint-disable-next-line no-console
             console.log(`Detected environment variable. Skipping CLI command.`);
             env = process.env;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "faker": "5.5.3",
         "jest": "27.5.1",
         "jest-when": "3.5.1",
-        "mockdate": "^3.0.5",
+        "mockdate": "3.0.5",
         "nock": "13.2.4",
         "prettier": "2.6.1"
       },


### PR DESCRIPTION
Hello,

The gitlab api has changed concerning the content of its endpoint in order to create a release. I have updated this part.

I updated the documentation about the nodejs version number.

I also corrected the detection of CI environment variables, which seems to me more accurate this way.

My PR also refers to the issue https://github.com/jk1z/gitlab-release-note-generator/issues/38